### PR TITLE
Add raw export options and dropdown export menu

### DIFF
--- a/public/records.html
+++ b/public/records.html
@@ -44,10 +44,21 @@
           </div>
           <div class="toolbar-actions">
             <button id="load">Load</button>
-            <button id="pdf" class="ghost" title="Open monthly PDF">Report PDF</button>
+            <div class="dropdown" id="export-dropdown">
+              <button id="export-trigger">Export Report ▾</button>
+              <div class="dropdown-menu" id="export-menu" role="menu">
+                <button type="button" data-option="raw-pdf">Raw PDF</button>
+                <button type="button" data-option="raw-excel">Raw Excel</button>
+                <button type="button" data-option="detailed-pdf">Detailed Overview PDF</button>
+                <button type="button" data-option="email-raw-pdf">Send Raw PDF by Email</button>
+                <button type="button" data-option="email-raw-excel">Send Raw Excel by Email</button>
+                <button type="button" data-option="email-detailed-pdf">Send Detailed Overview PDF by Email</button>
+              </div>
+            </div>
           </div>
         </div>
         <div id="summary" class="muted"></div>
+        <div id="export-status" class="muted small" style="margin-top:8px"></div>
       </section>
 
       <section class="panel">
@@ -71,12 +82,6 @@
         </div>
       </section>
 
-      <section class="panel">
-        <div class="field">
-          <button id="send-summary">Send summary email</button>
-          <span id="send-status" class="muted" style="margin-left:8px"></span>
-        </div>
-      </section>
     </main>
 
     <script>
@@ -84,17 +89,16 @@
       const listEl = document.getElementById('list');
       const summaryEl = document.getElementById('summary');
       const loadBtn = document.getElementById('load');
-      const sendBtn = document.getElementById('send-summary');
-      const sendStatus = document.getElementById('send-status');
-      const pdfBtn = document.getElementById('pdf');
+      const exportDropdown = document.getElementById('export-dropdown');
+      const exportTrigger = document.getElementById('export-trigger');
+      const exportMenu = document.getElementById('export-menu');
+      const exportStatus = document.getElementById('export-status');
 
       function currentMonth() {
         const d = new Date();
         const m = String(d.getMonth()+1).padStart(2, '0');
         return `${d.getFullYear()}-${m}`;
       }
-
-      function chfSymbol(){ return 'CHF'; }
 
       async function load(month) {
         listEl.innerHTML = '<tr><td colspan="9">Loading…</td></tr>';
@@ -164,27 +168,53 @@
         }
       }
 
-      document.getElementById('load').addEventListener('click', () => load(monthEl.value));
+      if (loadBtn) {
+        loadBtn.addEventListener('click', () => load(monthEl.value));
+      }
 
-      sendBtn.addEventListener('click', async () => {
-        sendStatus.textContent = 'Sending…';
-        try {
-          const m = monthEl.value || currentMonth();
-          const res = await fetch(`/api/send-summary?month=${encodeURIComponent(m)}`, { method: 'POST' });
-          const data = await res.json();
-          if (!res.ok || !data.ok) throw new Error(data.error || 'Failed');
-          sendStatus.textContent = `Sent summary for ${data.month} (count: ${data.count}, total: CHF ${Number(data.total||0).toFixed(2)})`;
-        } catch (err) {
-          sendStatus.textContent = 'Error: ' + err.message;
-        }
-      });
-
-      pdfBtn.addEventListener('click', () => {
-        const m = monthEl.value || currentMonth();
-        const ts = Date.now();
-        const url = `/api/expense-report.pdf?month=${encodeURIComponent(m)}&ts=${ts}`;
-        window.open(url, '_blank');
-      });
+      if (exportTrigger && exportDropdown && exportMenu) {
+        const hideMenu = () => exportDropdown.classList.remove('open');
+        exportTrigger.addEventListener('click', (ev) => {
+          ev.stopPropagation();
+          exportDropdown.classList.toggle('open');
+        });
+        document.addEventListener('click', (ev) => {
+          if (!exportDropdown.contains(ev.target)) hideMenu();
+        });
+        document.addEventListener('keydown', (ev) => {
+          if (ev.key === 'Escape') hideMenu();
+        });
+        exportMenu.querySelectorAll('button[data-option]').forEach((btn) => {
+          btn.addEventListener('click', async (ev) => {
+            ev.stopPropagation();
+            const option = btn.getAttribute('data-option');
+            if (!option) return;
+            hideMenu();
+            const month = monthEl.value || currentMonth();
+            if (option.startsWith('email-')) {
+              if (exportStatus) exportStatus.textContent = 'Sending…';
+              try {
+                const res = await fetch(`/api/export-report?month=${encodeURIComponent(month)}`, {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ option })
+                });
+                const data = await res.json().catch(() => ({}));
+                if (!res.ok || data.ok === false) throw new Error(data.error || 'Failed to send');
+                if (exportStatus) exportStatus.textContent = `Email queued for ${data.month} (${data.variantLabel})`;
+                if (window.showToast) showToast('Email queued', 'success');
+              } catch (err) {
+                if (exportStatus) exportStatus.textContent = 'Error: ' + err.message;
+                if (window.showToast) showToast(err.message, 'error');
+              }
+            } else {
+              const params = new URLSearchParams({ month, option, ts: Date.now().toString() });
+              window.open(`/api/export-report?${params.toString()}`, '_blank');
+              if (exportStatus) exportStatus.textContent = '';
+            }
+          });
+        });
+      }
 
       const cm = currentMonth();
       monthEl.value = cm;

--- a/public/report.html
+++ b/public/report.html
@@ -36,9 +36,39 @@
         <div class="flex items-center gap-2">
           <input id="month" type="month" class="input input-bordered input-sm" />
           <button id="load" class="btn btn-sm">Load</button>
-          <a id="pdf" class="btn btn-sm btn-outline" target="_blank">PDF</a>
+          <div class="relative" id="export-dropdown">
+            <button id="export-trigger" class="btn btn-sm">Export Report ▾</button>
+            <div
+              id="export-menu"
+              class="absolute right-0 mt-2 w-64 bg-base-100 border border-base-300 rounded-xl shadow-xl hidden z-50"
+            >
+              <button type="button" data-option="raw-pdf" class="block w-full text-left px-4 py-2 hover:bg-base-200">
+                Raw PDF
+              </button>
+              <button type="button" data-option="raw-excel" class="block w-full text-left px-4 py-2 hover:bg-base-200">
+                Raw Excel
+              </button>
+              <button type="button" data-option="detailed-pdf" class="block w-full text-left px-4 py-2 hover:bg-base-200">
+                Detailed Overview PDF
+              </button>
+              <button type="button" data-option="email-raw-pdf" class="block w-full text-left px-4 py-2 text-blue-600 hover:bg-base-200">
+                Send Raw PDF by Email
+              </button>
+              <button type="button" data-option="email-raw-excel" class="block w-full text-left px-4 py-2 text-blue-600 hover:bg-base-200">
+                Send Raw Excel by Email
+              </button>
+              <button
+                type="button"
+                data-option="email-detailed-pdf"
+                class="block w-full text-left px-4 py-2 text-blue-600 hover:bg-base-200"
+              >
+                Send Detailed Overview PDF by Email
+              </button>
+            </div>
+          </div>
         </div>
       </div>
+      <div id="export-status" class="text-xs opacity-70 text-right mt-2"></div>
 
       <!-- Executive Summary -->
       <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mt-6">
@@ -124,8 +154,12 @@
 
       const monthEl = document.getElementById('month');
       const btnLoad = document.getElementById('load');
-      const linkPdf = document.getElementById('pdf');
-      monthEl.value = currentMonth();
+      const exportDropdown = document.getElementById('export-dropdown');
+      const exportTrigger = document.getElementById('export-trigger');
+      const exportMenu = document.getElementById('export-menu');
+      const exportStatus = document.getElementById('export-status');
+      let currentPeriod = currentMonth();
+      monthEl.value = currentPeriod;
 
       async function load(){
         const m = monthEl.value || currentMonth();
@@ -147,7 +181,8 @@
 
         document.getElementById('title').textContent = `Monthly Expense Report — ${report.period}`;
         document.getElementById('subtitle').textContent = `Generated ${nowUTC()}`;
-        linkPdf.href = `/api/expense-report.pdf?month=${encodeURIComponent(report.period)}&ts=${Date.now()}`;
+        currentPeriod = report.period;
+        if (exportStatus) exportStatus.textContent = '';
 
         // Executive summary
         let g=0,n=0,v=0;
@@ -229,7 +264,56 @@
         }).join('');
       }
 
-      btnLoad.addEventListener('click', load);
+      if (btnLoad) {
+        btnLoad.addEventListener('click', load);
+      }
+
+      if (exportTrigger && exportMenu && exportDropdown) {
+        const hideMenu = () => exportMenu.classList.add('hidden');
+        const toggleMenu = () => {
+          if (exportMenu.classList.contains('hidden')) exportMenu.classList.remove('hidden');
+          else exportMenu.classList.add('hidden');
+        };
+        exportTrigger.addEventListener('click', (ev) => {
+          ev.stopPropagation();
+          toggleMenu();
+        });
+        document.addEventListener('click', (ev) => {
+          if (!exportDropdown.contains(ev.target)) hideMenu();
+        });
+        document.addEventListener('keydown', (ev) => {
+          if (ev.key === 'Escape') hideMenu();
+        });
+        exportMenu.querySelectorAll('button[data-option]').forEach((btn) => {
+          btn.addEventListener('click', async (ev) => {
+            ev.stopPropagation();
+            const option = btn.getAttribute('data-option');
+            if (!option) return;
+            hideMenu();
+            const period = currentPeriod || (monthEl.value || currentMonth());
+            if (option.startsWith('email-')) {
+              if (exportStatus) exportStatus.textContent = 'Sending email…';
+              try {
+                const res = await fetch(`/api/export-report?month=${encodeURIComponent(period)}`, {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ option })
+                });
+                const data = await res.json().catch(() => ({}));
+                if (!res.ok || data.ok === false) throw new Error(data.error || 'Failed to send');
+                if (exportStatus) exportStatus.textContent = `Email queued for ${data.month} (${data.variantLabel})`;
+              } catch (err) {
+                if (exportStatus) exportStatus.textContent = `Error: ${err.message}`;
+              }
+            } else {
+              const params = new URLSearchParams({ month: period, option, ts: Date.now().toString() });
+              window.open(`/api/export-report?${params.toString()}`, '_blank');
+              if (exportStatus) exportStatus.textContent = '';
+            }
+          });
+        });
+      }
+
       load();
     </script>
   </body>

--- a/public/styles.css
+++ b/public/styles.css
@@ -90,6 +90,14 @@ p{margin:0 0 18px;color:var(--muted)}
 /* Toolbar and table */
 .toolbar{display:flex;align-items:end;justify-content:space-between;gap:16px}
 .toolbar-actions{display:flex;gap:8px}
+.dropdown{position:relative;display:inline-flex;flex-direction:column}
+.dropdown>button{white-space:nowrap}
+.dropdown-menu{position:absolute;top:calc(100% + 6px);right:0;min-width:220px;padding:8px;background:linear-gradient(180deg,var(--panel),var(--card));border:1px solid var(--border);border-radius:12px;box-shadow:0 12px 30px rgba(0,0,0,0.25);display:none;flex-direction:column;z-index:60}
+.dropdown.open .dropdown-menu{display:flex}
+.dropdown-menu button{padding:10px 12px;background:transparent;border:none;color:var(--text);text-align:left;border-radius:10px;cursor:pointer}
+.dropdown-menu button:hover,.dropdown-menu button:focus{background:rgba(255,255,255,0.06);outline:none}
+.dropdown-menu button+button{margin-top:4px}
+.dropdown-menu button[data-option^="email-"]{color:var(--brand)}
 .table-wrap{overflow:auto}
 .table{width:100%;border-collapse:separate;border-spacing:0}
 .table th,.table td{padding:12px 10px;border-bottom:1px solid var(--border);text-align:left}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyairtable==2.3.5
 openai>=1.0,<2.0
 cloudinary==1.41.0
 reportlab==4.2.5
+openpyxl==3.1.5


### PR DESCRIPTION
## Summary
- add raw PDF/Excel generators plus a unified `/api/export-report` route that supports downloads and email delivery
- update records and report pages to use a single Export Report dropdown with the six format/delivery combinations
- extend shared styles and dependencies (openpyxl) to support the new export formats

## Testing
- python -m unittest server.test_reporting

------
https://chatgpt.com/codex/tasks/task_e_68c9837b36f483279b020f2d256b0064